### PR TITLE
Update plugin to support 7.12.0

### DIFF
--- a/elasticsearch/plugin-descriptor.properties
+++ b/elasticsearch/plugin-descriptor.properties
@@ -37,7 +37,7 @@ classname=org.elasticsearch.DieWithDignityPlugin
 java.version=1.8
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=6.2
+elasticsearch.version=7.12.0
 ### optional elements for plugins:
 #
 #  'extended.plugins': other plugins this plugin extends through SPI

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DieWithDignityPlugin</name>
     <groupId>org.elasticsearch.plugin</groupId>
     <artifactId>die-with-dignity</artifactId>
-    <version>7.0.0</version>
+    <version>7.12.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,7 @@
     <fileSets>
         <fileSet>
             <directory>elasticsearch</directory>
-            <outputDirectory>elasticsearch</outputDirectory>
+            <outputDirectory></outputDirectory>
             <includes>
                 <include>plugin-descriptor.properties</include>
             </includes>
@@ -16,7 +16,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>elasticsearch</outputDirectory>
+            <outputDirectory></outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>

--- a/src/main/java/org/elasticsearch/DieWithDignityPlugin.java
+++ b/src/main/java/org/elasticsearch/DieWithDignityPlugin.java
@@ -45,7 +45,7 @@ public class DieWithDignityPlugin extends Plugin implements ActionPlugin {
             final SettingsFilter settingsFilter,
             final IndexNameExpressionResolver indexNameExpressionResolver,
             final Supplier<DiscoveryNodes> nodesInCluster) {
-        return Collections.singletonList(new RestDieWithDignityAction(settings, restController));
+        return Collections.singletonList(new RestDieWithDignityAction());
     }
 
 }

--- a/src/main/java/org/elasticsearch/RestDieWithDignityAction.java
+++ b/src/main/java/org/elasticsearch/RestDieWithDignityAction.java
@@ -23,15 +23,25 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RestDieWithDignityAction extends BaseRestHandler {
 
-    RestDieWithDignityAction(final Settings settings, final RestController restController) {
-        super(settings);
-        restController.registerHandler(RestRequest.Method.GET, "/_die_with_dignity", this);
+    RestDieWithDignityAction() {
+        super();
+    }
+
+    @Override
+    public List<RestHandler.Route> routes() {
+        RestHandler.Route route = new RestHandler.Route(RestRequest.Method.GET, "/_die_with_dignity");
+        List<RestHandler.Route> routes = new ArrayList<RestHandler.Route>();
+        routes.add(route);
+        return routes;
     }
 
     @Override


### PR DESCRIPTION
Updates the plugin to version 7.12 of Elasticsearch. Notable changes:

* Fixes classes changes that happened from version 7.7
* Removes the intermediate `elasticsearch` directory that is no longer allowed in the plugin structure