### PR TITLE
Generate an OOM that triggers a heap dump

### DIFF
--- a/src/main/java/org/elasticsearch/RestDieWithDignityAction.java
+++ b/src/main/java/org/elasticsearch/RestDieWithDignityAction.java
@@ -51,7 +51,9 @@ public class RestDieWithDignityAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        // This should throw an OOM which generates a heap dump
+        long[] allocation = new long[Integer.MAX_VALUE];
+        // If that doesn't work, manually throw an OOM. This won't generate a heap dump
         throw new OutOfMemoryError("die with dignity");
     }
-
 }


### PR DESCRIPTION
The original code that threw an OOM doesn't trigger the `HeapDumpOnOutOfMemoryError` JVM flag, and no heap dump is created. This PR changes the way we create an OOM event so that a heap dump is generated like a true OOM event would.